### PR TITLE
fix: don't bake 'Unknown Author' into the gutter label (#8)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -158,7 +158,18 @@ exports.aceSetAuthorStyle = (hookName, context) => {
     z1$.borderRight = `solid 5px ${color}`;
     const z2$ = outerDynamicCSS.selectorStyle(
         `#sidedivinner.authorColors > div.primary-${authorClass}::before`);
-    z2$.content = `'${authorName}'`;
+    // Only write the label when we actually resolved a real name. If the
+    // user joined via ?userName=… the first aceSetAuthorStyle call often
+    // fires before USER_NEWINFO has populated #otheruserstable /
+    // historicalAuthorData, so the fallback was baking the literal text
+    // "Unknown Author" into CSS and it never updated when the name
+    // eventually arrived (#8). Leaving `content` unchanged means the
+    // later call (once the name is known) overwrites an empty rule with
+    // the correct label, while still showing the coloured border/highlight
+    // in the meantime.
+    if (authorName && authorName !== 'Unknown Author') {
+      z2$.content = `'${authorName}'`;
+    }
     z2$.paddingLeft = '5px';
     z2$.whiteSpace = 'nowrap';
     const z3$ = outerDynamicCSS.selectorStyle(

--- a/static/tests/backend/specs/unknown_author.js
+++ b/static/tests/backend/specs/unknown_author.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const assert = require('assert').strict;
+const fs = require('fs');
+const path = require('path');
+
+const indexPath = path.resolve(
+    __dirname, '..', '..', '..', '..', 'static', 'js', 'index.js');
+
+describe(__filename, function () {
+  let src;
+  before(function () { src = fs.readFileSync(indexPath, 'utf8'); });
+
+  it('aceSetAuthorStyle does not bake "Unknown Author" into ::before content (#8)',
+      function () {
+        const hookBody = src.match(/exports\.aceSetAuthorStyle\s*=\s*[\s\S]*?\n\};/);
+        assert(hookBody, 'expected aceSetAuthorStyle export');
+        // The hook used to write `z2$.content = '...${authorName}'` even
+        // when `authorName` came back as the placeholder "Unknown Author"
+        // (because USER_NEWINFO hadn't populated the user list yet). The
+        // label should only be written when we actually resolved a real
+        // name — otherwise the first render nails a wrong label into CSS
+        // that never updates.
+        assert(/authorName\s*!==\s*['"]Unknown Author['"]/.test(hookBody[0]),
+            'aceSetAuthorStyle should skip writing the CSS label when the resolved author name ' +
+            'is "Unknown Author" so a later USER_NEWINFO can overwrite it with the real name');
+      });
+});


### PR DESCRIPTION
Fixes #8. When a user joins via `?userName=…`, other clients' first `aceSetAuthorStyle` call runs before USER_NEWINFO has populated the author lookup (`#otheruserstable` + historicalAuthorData). The fallback `Unknown Author` string was being written straight into the ::before content rule for the line-author gutter. Later USER_NEWINFO updates triggered a second aceSetAuthorStyle, but the stale rule was already set. Skip writing content when we got the placeholder back — the later call overwrites an empty slot with the real name. The coloured border/highlight still renders in the meantime.