### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Demo](demo.gif) [![Backend Tests Status](https://github.com/ether/ep_author_neat2/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_author_neat2/actions/workflows/test-and-release.yml)
 
-# ep_author_neat2
+# Line Author Sidebar for Etherpad
 
 [Etherpad](https://etherpad.org) plugin that uses colored underlines instead of
 colored backgrounds to indicate authorship.


### PR DESCRIPTION
Replace the placeholder `ep_author_neat2` heading in README.md with "Line Author Sidebar for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.