### PR TITLE
chore: declare @feature:authorship-bg-color disable + use disables-aware test runner

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -69,4 +69,11 @@ jobs:
           done
           cd src
           pnpm exec playwright install chromium --with-deps
-          pnpm run test-ui --project=chromium
+          # Use the declared-disables helper instead of plain test-ui:
+          # ep_author_neat2 renders authorship as a coloured underline
+          # rather than a coloured background, so ep.json declares
+          # `disables: ["@feature:authorship-bg-color"]`. The helper
+          # runs two passes — regression (untagged tests must pass) +
+          # honesty (tagged tests must FAIL because the bg-color is
+          # genuinely gone). See doc/PLUGIN_FEATURE_DISABLES.md.
+          ../bin/run-frontend-tests-with-disables.sh -- --project=chromium

--- a/ep.json
+++ b/ep.json
@@ -1,4 +1,5 @@
 {
+  "disables": ["@feature:authorship-bg-color"],
   "parts": [
     {
       "name": "ep_author_neat2",


### PR DESCRIPTION
Wires ep_author_neat2 into the [declared-disables contract](https://github.com/ether/etherpad/pull/7648).

## Why this is a contract case

Per this plugin's README: *"uses colored underlines instead of colored backgrounds to indicate authorship"*. The single failing core spec (`change_user_color.spec.ts:59`) hard-asserts the chat `<p>` background is the user's colour — exactly the rendering this plugin replaces. [ether/etherpad-lite#7657](https://github.com/ether/etherpad/pull/7657) added the corresponding `@feature:authorship-bg-color` tag.

## Changes

- `ep.json`: declares `"disables": ["@feature:authorship-bg-color"]` so /admin and etherpad.org/plugins surface what this plugin replaces before install.
- `.github/workflows/frontend-tests.yml`: swaps `pnpm run test-ui` for `../bin/run-frontend-tests-with-disables.sh -- --project=chromium`. Two passes: regression (everything else passes) + honesty (the tagged test must fail under the plugin, proving the bg-color is genuinely gone).

Mirrors the four already-merged disable_* migrations (ep_disable_chat#75, change_author_name#84, error_messages#83, reset_authorship_colours#89).

🤖 Generated with [Claude Code](https://claude.com/claude-code)